### PR TITLE
Re-enable per-user MFA override

### DIFF
--- a/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
+++ b/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
@@ -7,7 +7,10 @@ function (user, context, callback) {
 
   var user_with_mfa = user.app_metadata && user.app_metadata.use_mfa;
 
-  if (mfa_enabled_connection) {
+  if (
+    user_with_mfa &&
+    mfa_enabled_connection
+  ) {
 
     context.multifactor = {
       provider: 'google-authenticator',


### PR DESCRIPTION
* Last commit ignores users'  `use_mfa` setting, which I was using to avoid having to do MFA every time I log in to my dev env.