### PR TITLE
Auth0 Rule for adding group claim to token

### DIFF
--- a/rules/add-group-claim-to-token.js
+++ b/rules/add-group-claim-to-token.js
@@ -1,0 +1,42 @@
+function (user, context, callback) {
+
+    var request   = require('request');
+    var namespace = 'https://dev.mojanalytics.xyz/claims/';  // For custom claims, you must define a namespace for oidc compliance. See https://auth0.com/docs/api-auth/tutorials/adoption/scope-custom-claims
+    var options   = {
+        url: 'https://api.github.com/user/teams',
+        headers: {
+            'Authorization': 'token ' + github_access_token(),
+            'User-Agent': 'request'
+        }
+    };
+
+    function github_access_token() {
+        var github_identity = _.find(user.identities,
+            {connection: 'github'});
+        var token = github_identity.access_token;
+        return token;
+    }
+
+    // Apply to github only
+    if (context.connection === 'github') {
+
+        request(options, function (error, response, body) {
+            if (response.statusCode !== 200) {
+
+                return callback(new Error('Error retrieving teams from github: ' + body || error));
+
+            } else {
+
+                var git_team = JSON.parse(body).map(function (team) {
+                    return team.slug;
+                });
+
+                // Add the namespaced claims to ID token
+                context.idToken[namespace + "groups"] = git_team.concat(user.groups);
+
+            }
+
+            return callback(null, user, context);
+        });
+    }
+}


### PR DESCRIPTION
Trello: https://trello.com/c/QJTNs9QM

The rule adds auth0 groups and github teams to a namespaced groups claim
in a user's id token.

Group claims are classified as custom claims and must be namespaced to be oidc
compliant. See:
https://auth0.com/docs/api-auth/tutorials/adoption/scope-custom-claims

These claims can later be consumed/queried by applications/services.

I added this rule for assigning roles to groups via role-bindings with the k8s api, but this is not the only use case.