### PR TITLE
App Metadata

### DIFF
--- a/rules/add-group-claim-to-token.js
+++ b/rules/add-group-claim-to-token.js
@@ -32,7 +32,7 @@ function (user, context, callback) {
                 });
 
                 // Add the namespaced claims to ID token
-                context.idToken[namespace + "groups"] = git_team.concat(user.groups);
+                context.idToken[namespace + "groups"] = git_team.concat(user.app_metadata.authorization.groups);
 
             }
 


### PR DESCRIPTION
__Allowing this rule to bed-in in dev before applying to alpha__

Auth0 have stated that there is no synchronization taking place between
the data in the Authorization Extension and the user's profile.

To access data from the Authorization Extension we must query a user's
app_metadata.

See: https://auth0.com/docs/metadata#metadata-usage