### PR TITLE
Remove Metadata

### DIFF
--- a/rules/add-group-claim-to-token.js
+++ b/rules/add-group-claim-to-token.js
@@ -32,7 +32,7 @@ function (user, context, callback) {
         });
 
         // Add the namespaced claims to ID token
-        context.idToken[namespace + "groups"] = git_teams.concat(user.groups);
+        context.idToken[namespace + "groups"] = git_teams;
       }
 
       return callback(null, user, context);


### PR DESCRIPTION
We wanted all groups/teams to be defined in github in the first place.
Dropping groups from auth0 as it makes the process unstable with auth0's
constant changes.