### PR TITLE
Challenge for 2FA every 8 hours + Refactoring (dev)

### DIFF
--- a/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
+++ b/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
@@ -1,36 +1,74 @@
 function (user, context, callback) {
-
-    var mfa_enabled_connection = [
+    var AUTHENTICATOR_LABEL = 'MOJ Analytical Platform (dev)';
+    var DISABLED_CLIENTS = [
+        'p4L2qRcSgWyqHjoHanJ4QyhWL1iX612i', // kubectl-oidc
+    ];
+    var ENABLED_CONNECTIONS = [
         'github',
-        'google-oauth2'
-    ].indexOf(context.connection) !== -1;
+        'google-oauth2',
+    ];
+    var MFA_CHALLENGE_EVERY_MINUTES = 8 * 60; // 8 hours
 
-    // Exclude the following clients from mfa
-    var mfa_disabled_clients = [
-        'p4L2qRcSgWyqHjoHanJ4QyhWL1iX612i'
-    ].indexOf(context.clientID) === -1;
 
-    var user_with_mfa = user.app_metadata && user.app_metadata.use_mfa;
+    var enabled_for_user = !user.app_metadata || user.app_metadata.use_mfa !== false;
+    var enabled_for_connection = ENABLED_CONNECTIONS.indexOf(context.connection) !== -1;
+    var enabled_for_client = DISABLED_CLIENTS.indexOf(context.clientID) === -1;
 
-    if (
-        user_with_mfa &&
-        mfa_enabled_connection &&
-        mfa_disabled_clients
-    ) {
+    if ( !enabled_for_user || !enabled_for_connection || !enabled_for_client ) {
+        console.log('2FA disabled for user, connection or client');
+        return callback(null, user, context);
+    }
 
+    getUserProfile(user)
+        .then(function (user_profile) {
+            if ( !loggedInRecently(user_profile) ) {
+                console.log('user did not log in recently - enabling MFA');
+                enableMFA(context);
+            }
+
+            return callback(null, user, context);
+        })
+        .catch(function(err) {
+            enableMFA(context);
+            return callback(null, user, context);
+        });
+
+
+    // Utility functions
+
+    function enableMFA(context) {
         context.multifactor = {
             provider: 'google-authenticator',
-
             // optional, the label shown in the authenticator app
-            issuer: 'MOJ Analytical Platform (dev)',
-
-            // optional, the key to use for TOTP. By default one is generated for you
-            // key: '{YOUR_KEY_HERE}',
-
+            issuer: AUTHENTICATOR_LABEL,
             // optional, defaults to true. false forces 2FA every time.
-            allowRememberBrowser: false
+            allowRememberBrowser: false,
         };
     }
 
-    callback(null, user, context);
+    function loggedInRecently(user_profile) {
+        if (user_profile.last_login) {
+            var secs_from_last_login = (new Date() - new Date(user_profile.last_login)) / 1000;
+
+            if (secs_from_last_login < 5) {
+                return false;
+            }
+
+            return (secs_from_last_login / 60) < MFA_CHALLENGE_EVERY_MINUTES;
+        }
+
+        return false;
+    }
+
+    function getUserProfile(user) {
+        var AUTH0_VERSION = '2.9.1';
+        var ManagementClient = require('auth0@' + AUTH0_VERSION).ManagementClient;
+        var management = new ManagementClient({
+            token: auth0.accessToken,
+            domain: auth0.domain,
+        });
+
+        return management.users.get({ id: user.user_id });
+    }
+
 }

--- a/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
+++ b/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
@@ -10,31 +10,27 @@ function (user, context, callback) {
     var MFA_CHALLENGE_EVERY_MINUTES = 8 * 60; // 8 hours
 
 
-    var enabled_for_user = !user.app_metadata || user.app_metadata.use_mfa !== false;
-    var enabled_for_connection = ENABLED_CONNECTIONS.indexOf(context.connection) !== -1;
-    var enabled_for_client = DISABLED_CLIENTS.indexOf(context.clientID) === -1;
+    var disabled_for_user = user.app_metadata && user.app_metadata.use_mfa === false;
+    var disabled_for_connection = ENABLED_CONNECTIONS.indexOf(context.connection) === -1;
+    var disabled_for_client = DISABLED_CLIENTS.indexOf(context.clientID) !== -1;
 
-    if ( !enabled_for_user || !enabled_for_connection || !enabled_for_client ) {
-        console.log('2FA disabled for user, connection or client');
-        return callback(null, user, context);
+    if (disabled_for_user || disabled_for_connection || disabled_for_client) {
+        callback(null, user, context);
     }
 
     getUserProfile(user)
         .then(function (user_profile) {
-            if ( !loggedInRecently(user_profile) ) {
-                console.log('user did not log in recently - enabling MFA');
+            if (!loggedInRecently(user_profile)) {
                 enableMFA(context);
             }
 
-            return callback(null, user, context);
+            callback(null, user, context);
         })
         .catch(function(err) {
             enableMFA(context);
-            return callback(null, user, context);
+            callback(null, user, context);
         });
 
-
-    // Utility functions
 
     function enableMFA(context) {
         context.multifactor = {
@@ -50,6 +46,17 @@ function (user, context, callback) {
         if (user_profile.last_login) {
             var secs_from_last_login = (new Date() - new Date(user_profile.last_login)) / 1000;
 
+            // User goes throught this rule twice apparently.
+            // 1) The first time, if the user didn't log in recently we'll
+            // add the MFA configuration to the context.
+            // 1a) Auth0 updates the user `last_login` even if they were not
+            // challenged for 2FA yet
+            // 2) The second time we'll need to add the MFA configuration to the
+            // context again or they will not be challenged.
+            //
+            // Because we need to account for 1a) we don't consider a login in
+            // the last 5 seconds as a login. That's an arbitrary short number
+            // of seconds to account for the redirect to challenge users for MFA.
             if (secs_from_last_login < 5) {
                 return false;
             }


### PR DESCRIPTION
Before this change we were challenging for 2FA at every login.
This was alright but as we want to have a more streamlined user experience
and enable silent SSO this is not a problem.

The rule now check when was last time a user logged in (by getting the full
Auth0 profile which contains `last_login`) and only challenge if he/she
didn't login in the last 8 hours.

### NOTE
From empiric experience it seems like the user goes through this rule twice. 
When user goes through rule the first time their `last_login` field is updated even if they didn't enter the 2FA code yet (unfortunately).

This is the reason why if user logged in less than 5 seconds I consider that as a non-login and re-enforce 2FA (otherwise they will not be challenged). 
I also tested that if user waits before clicking on "login" button they will still be challenged for 2FA code.


### Ticket
Part of https://trello.com/c/PqvTE1VQ/672-4-update-auth0-rule-to-challenge-for-2fa-every-8h