### PR TITLE
Reverting change which removed `return` in MFA rule

### DIFF
--- a/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
+++ b/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
@@ -15,7 +15,7 @@ function (user, context, callback) {
     var disabled_for_client = DISABLED_CLIENTS.indexOf(context.clientID) !== -1;
 
     if (disabled_for_user || disabled_for_connection || disabled_for_client) {
-        callback(null, user, context);
+        return callback(null, user, context);
     }
 
     getUserProfile(user)
@@ -24,11 +24,11 @@ function (user, context, callback) {
                 enableMFA(context);
             }
 
-            callback(null, user, context);
+            return callback(null, user, context);
         })
         .catch(function(err) {
             enableMFA(context);
-            callback(null, user, context);
+            return callback(null, user, context);
         });
 
 


### PR DESCRIPTION
This seems to force 2FA more than the necessary.

Have the `return` is also more explicit.