### PR TITLE
Challenge Control Panel users for 2FA

### DIFF
--- a/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
+++ b/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
@@ -1,8 +1,5 @@
 function (user, context, callback) {
     var AUTHENTICATOR_LABEL = 'MOJ Analytical Platform (dev)';
-    var DISABLED_CLIENTS = [
-        'p4L2qRcSgWyqHjoHanJ4QyhWL1iX612i', // kubectl-oidc
-    ];
     var ENABLED_CONNECTIONS = [
         'github',
         'google-oauth2',
@@ -12,9 +9,9 @@ function (user, context, callback) {
 
     var disabled_for_user = user.app_metadata && user.app_metadata.use_mfa === false;
     var disabled_for_connection = ENABLED_CONNECTIONS.indexOf(context.connection) === -1;
-    var disabled_for_client = DISABLED_CLIENTS.indexOf(context.clientID) !== -1;
+    var is_refresh_token_grant = context.protocol === 'oauth2-refresh-token';
 
-    if (disabled_for_user || disabled_for_connection || disabled_for_client) {
+    if (disabled_for_user || disabled_for_connection || is_refresh_token_grant) {
         return callback(null, user, context);
     }
 


### PR DESCRIPTION
### Background

kubernetes, CP-API and CP-UI use the same Auth0 client (as JWT tokens are
passed from UI down to UI).

### Old behaviour

The rule ignored `kubectl-oidc` client as the kubectl is a command line
utility and we don't challenge for 2FA in that context.

As a side effect of this, we also don't challenge users for 2FA when
logging in CP.

See: [Auth0 documentation on Refresh Token Exchange](https://auth0.com/docs/tokens/refresh-token/current#rules)

### New behaviour

The rule is now not challenging for 2FA when client is using a refresh token
(as they already authenticated and this is also non-interactive).
