### PR TITLE
DEV: Fix for org whitelist rule when context.connection not set

### DIFF
--- a/rules/whitelist-github-orgs.js
+++ b/rules/whitelist-github-orgs.js
@@ -4,8 +4,8 @@ function (user, context, callback) {
   var whitelist = ['moj-analytical-services']; // authorized github orgs
 
   // Apply to 'github' connections only
-  if(context.connection === 'github'){
-    var github_identity = _.find(user.identities, { connection: 'github' });
+  var github_identity = _.find(user.identities, { connection: 'github' });
+  if (github_identity) {
     var access_token = github_identity.access_token;
 
     request({


### PR DESCRIPTION
A user managed to log in the CP despite not being part of the org
yet. From some manual testing it appears that the problem is that
the Auth0 rule is somehow "skipped" when `context` doesn't have
a `connection` key.

This rule should be skipped when the user is not logging using
GitHub (e.g. Google) and that's why it was checking `context.connection`
to see if this value is `github`.

This value doesn't seem to be always there so I'm changing this logic to
check if the user has a `github` identity.

NOTE: A person logging in with different identities will have different users
with different identities.