### PR TITLE
ALPHA: Replace `context.connection` with something more reliable

### DIFF
--- a/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
+++ b/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
@@ -1,5 +1,6 @@
 function (user, context, callback) {
     var AUTHENTICATOR_LABEL = 'MOJ Analytical Platform (Alpha)';
+    var CONNECTION = user.identities[0].connection;
     var ENABLED_CONNECTIONS = [
         'github',
         'google-oauth2',
@@ -8,7 +9,7 @@ function (user, context, callback) {
 
 
     var disabled_for_user = user.app_metadata && user.app_metadata.use_mfa === false;
-    var disabled_for_connection = ENABLED_CONNECTIONS.indexOf(context.connection) === -1;
+    var disabled_for_connection = ENABLED_CONNECTIONS.indexOf(CONNECTION) === -1;
     var is_refresh_token_grant = context.protocol === 'oauth2-refresh-token';
 
     if (disabled_for_user || disabled_for_connection || is_refresh_token_grant) {

--- a/rules/add-group-claim-to-token.js
+++ b/rules/add-group-claim-to-token.js
@@ -4,19 +4,16 @@ function (user, context, callback) {
     'oUb1V330oXKyMpTagAYDzWDY10U4ffWF'
   ].indexOf(context.clientID) !== -1;
 
-  function github_access_token() {
-    var github_identity = _.find(user.identities, {connection: 'github'});
-    return github_identity.access_token;
-  }
+  var github_identity = _.find(user.identities, {connection: 'github'});
 
-  if (context.connection === 'github' && targeted_clients) {
+  if (github_identity && targeted_clients) {
     // For custom claims, you must define a namespace for oidc compliance.
     // See https://auth0.com/docs/api-auth/tutorials/adoption/scope-custom-claims
     var namespace = 'https://api.alpha.mojanalytics.xyz/claims/';
     var options = {
       url: 'https://api.github.com/user/teams',
       headers: {
-        'Authorization': 'token ' + github_access_token(),
+        'Authorization': 'token ' + github_identity.access_token,
         'User-Agent': 'request'
       }
     };

--- a/rules/auth0-authorization-extension.js
+++ b/rules/auth0-authorization-extension.js
@@ -4,7 +4,8 @@
  */
 function (user, context, callback) {
   // If connection is not passwordless skip this rule
-  if (context.connection !== 'email') {
+  var connection = user.identities[0].connection;
+  if (connection !== 'email') {
     return callback(null, user, context);
   }
 
@@ -51,7 +52,7 @@ function (user, context, callback) {
         "x-api-key": API_KEY
       },
       json: {
-        connectionName: context.connection || user.identities[0].connection,
+        connectionName: 'email',
         groups: user.groups
       },
       timeout: 5000

--- a/rules/whitelist-google-domains.js
+++ b/rules/whitelist-google-domains.js
@@ -2,8 +2,8 @@ function (user, context, callback) {
     var whitelist = ['digital.justice.gov.uk']; //authorized domains
 
     // Apply to 'google-oauth2' connections only
-    if(context.connection === 'google-oauth2'){
-
+    var connection = user.identities[0].connection;
+    if (connection === 'google-oauth2') {
       var userHasAccess = whitelist.some(
         function (domain) {
           var emailSplit = user.email.split('@');
@@ -13,7 +13,6 @@ function (user, context, callback) {
       if (!userHasAccess) {
         return callback(new UnauthorizedError('Access denied.'));
       }
-
     }
 
     return callback(null, user, context);


### PR DESCRIPTION
Problem
======
We found that a rule was not working as expected as it was skipped even
when it shouldn't have. This was caused by the following statement:

    // Apply rule only if logging in via GitHub
    if (context.connection !== 'github') {
      // ...
    }

The problem was that sometimes `context.connection` is not set causing
the rule to be skipped when it shouldn't.

I've updated similar logic here to avoid this kind of problem.

Rules now look at user identities. Our Auth0 users have only one identity
so `context.connection` is replaced with `user.identities[0].connection`.

Updated rules
=============
- `add-group-claim-to-token`: This only needs to run when logging using
  GH via certain clients
- `auth0-authorization-extension`: Only runs when connection type is `email`.
  I updated the logic and also replaced unnecessary logic to determine
  connection (`context.connection || user.identities[0].connection`) with
  a constant (`email`) as the connection will always be email in this rule.
- `Multifactor-Google-Authenticator-Do-Not-Rename`: Only applied to certain
  connections
- `whitelist-google-domains`: Only apply when logging in via Google

Ticket
======

https://trello.com/c/ldYtid7e/775-1-auth0-rules-dont-use-contextconnection