### PR TITLE
#810 Skip Auth0 2FA if user is on DOM1 [WIP]

### DIFF
--- a/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
+++ b/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
@@ -7,8 +7,20 @@ function (user, context, callback) {
         'github',
         'google-oauth2',
     ];
-
-    //console.log('ip: ' + context.request.ip);
+    var CORPORATE_NETWORK_CIDRS = [
+        '157.203.176.138/31',
+        '157.203.176.140/32',
+        '157.203.177.190/31',
+        '157.203.177.192/32',
+        '212.137.36.224/28',
+        '62.25.109.192/28',
+        '81.134.202.29/32',
+        '195.59.75.0/24',
+        '194.33.192.0/25',
+        '194.33.193.0/25',
+        '194.33.196.0/25',
+        '194.33.197.0/25',
+    ];
 
     var disabled_for_user = user.app_metadata && user.app_metadata.use_mfa === false;
     var disabled_for_connection = ENABLED_CONNECTIONS.indexOf(CONNECTION) === -1;
@@ -18,17 +30,11 @@ function (user, context, callback) {
         return callback(null, user, context);
     }
 
-    // Skip MFA if user's IP is on a corporate network
-    // configuration.CORPORATE_NETWORK_CIDRS is a space separated list of IP address ranges (CIDR notation)
     var userIsOnCorporateNetwork =
-        rangeCheck.inRange(context.request.ip, configuration.CORPORATE_NETWORK_CIDRS.split(' '));
+        rangeCheck.inRange(context.request.ip, CORPORATE_NETWORK_CIDRS);
     if (!userIsOnCorporateNetwork) {
-        //console.log('Not on corporate network. Enabling MFA.');
         enableMFA(context);
     }
-    //else {
-    //    console.log('On corporate network. No MFA challenge (from Auth0 at least).');
-    //}
 
     function enableMFA(context) {
         context.multifactor = {

--- a/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
+++ b/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
@@ -1,11 +1,12 @@
 function (user, context, callback) {
+    var rangeCheck = require('range_check');
+
     var AUTHENTICATOR_LABEL = 'MOJ Analytical Platform (Alpha)';
     var CONNECTION = user.identities[0].connection;
     var ENABLED_CONNECTIONS = [
         'github',
         'google-oauth2',
     ];
-    var MFA_CHALLENGE_EVERY_MINUTES = 8 * 60; // 8 hours
 
     //console.log('ip: ' + context.request.ip);
 
@@ -18,14 +19,9 @@ function (user, context, callback) {
     }
 
     // Skip MFA if user's IP is on a corporate network
-    var CORPORATE_NETWORK_IPS = [
-        // https://github.com/ministryofjustice/moj-ip-addresses/blob/master/moj-cidr-addresses.yml
-    ];
-    var userIsOnCorporateNetwork = CORPORATE_NETWORK_IPS.some(
-    function (ip) {
-        return context.request.ip === ip;
-    });
-
+    // configuration.CORPORATE_NETWORK_CIDRS is a space separated list of IP address ranges (CIDR notation)
+    var userIsOnCorporateNetwork =
+        rangeCheck.inRange(context.request.ip, configuration.CORPORATE_NETWORK_CIDRS.split(' '));
     if (!userIsOnCorporateNetwork) {
         //console.log('Not on corporate network. Enabling MFA.');
         enableMFA(context);

--- a/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
+++ b/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
@@ -7,6 +7,7 @@ function (user, context, callback) {
     ];
     var MFA_CHALLENGE_EVERY_MINUTES = 8 * 60; // 8 hours
 
+    //console.log('ip: ' + context.request.ip);
 
     var disabled_for_user = user.app_metadata && user.app_metadata.use_mfa === false;
     var disabled_for_connection = ENABLED_CONNECTIONS.indexOf(CONNECTION) === -1;
@@ -16,19 +17,22 @@ function (user, context, callback) {
         return callback(null, user, context);
     }
 
-    getUserProfile(user)
-        .then(function (user_profile) {
-            if (!loggedInRecently(user_profile)) {
-                enableMFA(context);
-            }
+    // Skip MFA if user's IP is on a corporate network
+    var CORPORATE_NETWORK_IPS = [
+        // https://github.com/ministryofjustice/moj-ip-addresses/blob/master/moj-cidr-addresses.yml
+    ];
+    var userIsOnCorporateNetwork = CORPORATE_NETWORK_IPS.some(
+    function (ip) {
+        return context.request.ip === ip;
+    });
 
-            return callback(null, user, context);
-        })
-        .catch(function(err) {
-            enableMFA(context);
-            return callback(null, user, context);
-        });
-
+    if (!userIsOnCorporateNetwork) {
+        //console.log('Not on corporate network. Enabling MFA.');
+        enableMFA(context);
+    }
+    //else {
+    //    console.log('On corporate network. No MFA challenge (from Auth0 at least).');
+    //}
 
     function enableMFA(context) {
         context.multifactor = {
@@ -40,40 +44,5 @@ function (user, context, callback) {
         };
     }
 
-    function loggedInRecently(user_profile) {
-        if (user_profile.last_login) {
-            var secs_from_last_login = (new Date() - new Date(user_profile.last_login)) / 1000;
-
-            // User goes throught this rule twice apparently.
-            // 1) The first time, if the user didn't log in recently we'll
-            // add the MFA configuration to the context.
-            // 1a) Auth0 updates the user `last_login` even if they were not
-            // challenged for 2FA yet
-            // 2) The second time we'll need to add the MFA configuration to the
-            // context again or they will not be challenged.
-            //
-            // Because we need to account for 1a) we don't consider a login in
-            // the last 5 seconds as a login. That's an arbitrary short number
-            // of seconds to account for the redirect to challenge users for MFA.
-            if (secs_from_last_login < 5) {
-                return false;
-            }
-
-            return (secs_from_last_login / 60) < MFA_CHALLENGE_EVERY_MINUTES;
-        }
-
-        return false;
-    }
-
-    function getUserProfile(user) {
-        var AUTH0_VERSION = '2.9.1';
-        var ManagementClient = require('auth0@' + AUTH0_VERSION).ManagementClient;
-        var management = new ManagementClient({
-            token: auth0.accessToken,
-            domain: auth0.domain,
-        });
-
-        return management.users.get({ id: user.user_id });
-    }
-
+    return callback(null, user, context);
 }


### PR DESCRIPTION
Previous behaviour:
* log in to Control Panel with Auth0 Universal Login - click "Log in with GitHub" page, followed by 2FA challenge
* then log in to R Studio without interaction, because Silent SSO and no 2FA challenge
However there was the bug with the 2FA challenge.

With this PR when on DOM1/MojDigital network:
* log in to Control Panel with Auth0 Universal Login - click "Log in with GitHub" page (no 2FA challenge)
* then log in to R Studio without interaction, because Silent SSO and no 2FA challenge
i.e. an improved experience

With this PR when NOT on DOM1/MojDigital network - 2FA "always challenge":
* log in to Control Panel with Auth0 Universal Login - click "Log in with GitHub" page, followed by 2FA challenge
* then log in to R Studio with Auth0 Universal Login - click "Log in with GitHub" page, followed by 2FA challenge
i.e. control panel and R Studio logins seem separate.
"Silent SSO" doesn't work any more because of the 2FA challenge every time.

This is currently deployed to dev. @RobinL can you test this with your DOM1 machine please?

I've included DOM1 and MoJDigital wifi and asked about any others.