### PR TITLE
Only add team names from allowed Github orgs

### DIFF
--- a/rules/add-group-claim-to-token.js
+++ b/rules/add-group-claim-to-token.js
@@ -24,8 +24,15 @@ function (user, context, callback) {
         return callback(new Error('Error retrieving teams from github: ' + body || error));
 
       } else {
+        var github_orgs = [
+          "ministryofjustice",
+          "moj-analytical-services",
+        ];
         var git_teams = JSON.parse(body).map(function (team) {
-          return team.slug;
+          if (team.organization.login in github_orgs) {
+            // TODO: namespace slugs by org
+            return team.slug;
+          }
         });
 
         // Add the namespaced claims to ID token


### PR DESCRIPTION
Otherwise a user could be a member of an `admin` group (for example) in another org and be given inappropriate access.