### PR TITLE
Revert: Only add team names from allowed Github orgs

### DIFF
--- a/rules/add-group-claim-to-token.js
+++ b/rules/add-group-claim-to-token.js
@@ -24,15 +24,8 @@ function (user, context, callback) {
         return callback(new Error('Error retrieving teams from github: ' + body || error));
 
       } else {
-        var github_orgs = [
-          "ministryofjustice",
-          "moj-analytical-services",
-        ];
         var git_teams = JSON.parse(body).map(function (team) {
-          if (team.organization.login in github_orgs) {
-            // TODO: namespace slugs by org
-            return team.slug;
-          }
+          return team.slug;
         });
 
         // Add the namespaced claims to ID token


### PR DESCRIPTION
Reverts [PR](https://github.com/ministryofjustice/analytics-platform-auth0/pull/39)

RBAC policies associated with `group` claim are not working

```
Error from server (Forbidden): pods is forbidden: User "https://alpha-analytics-moj.eu.auth0.com/#djsd123" cannot list pods in the namespace "apps-prod"
```
Revert "Only add team names from allowed Github orgs (#39)"

This reverts commit f211856261dbdabd24e05a09d56ca3e4b5643f0f