### PR TITLE
Github Orgs

### DIFF
--- a/rules/add-group-claim-to-token.js
+++ b/rules/add-group-claim-to-token.js
@@ -29,7 +29,7 @@ function (user, context, callback) {
           "moj-analytical-services",
         ];
         var git_teams = JSON.parse(body).map(function (team) {
-          if (team.organization.login in github_orgs) {
+          if (github_orgs.includes(team.organization.login)) {
             // TODO: namespace slugs by org
             return team.slug;
           }


### PR DESCRIPTION
Auth broke this morning because the organization __in__ github_orgs undefined objects being returned.

    ```
              if (team.organization.login in github_orgs) {
                // TODO: namespace slugs by org
                return team.slug;
              }

    ```

It appears Auth0 changed the default runtime from __not sure__ to __Node 8__ which does not support the `in` operator on an array in the same way.

Changing to a map.