### PR TITLE
Passwordless link lasts 60 minutes now

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@ Rules and static pages for Auth0
 
 NB branches are used for each environment, so look at e.g. `dev` or `alpha` branches.
 
-## emails
-
-These are manually deployed - copy and paste into the Auth0 web console.
-
 ## rules
 
 Automated deployment - see: https://github.com/ministryofjustice/analytics-platform-ops#auth0-rules--hosted-pages
+
+## emails
+
+These are manually deployed - copy and paste into the Auth0 web console, from 'master' branch.
+
+* passwordless.html - https://manage.auth0.com/dashboard/eu/alpha-analytics-moj/connections/passwordless
 
 ## hosted_pages
 

--- a/emails/templates/login-link.html
+++ b/emails/templates/login-link.html
@@ -1,6 +1,6 @@
 <p class="main">
   Click and confirm that you want to sign in to {{ application.name }}.
-  This link will expire in thirty minutes.
+  This link will expire in sixty minutes.
 </p>
 
 <div class="call-to-action">


### PR DESCRIPTION
This is already deployed manually on the Auth0 web console.