### PR TITLE
dev: Fix crown image broken image

### DIFF
--- a/pages/login.html
+++ b/pages/login.html
@@ -143,7 +143,7 @@ Copyright © 2017 Javan Makhmali
         scope: "openid email profile repo read:user read:org",
       },
       theme: {
-        logo:            'https://controlpanel.services.dev.mojanalytics.xyz/static/govuk-frontend/assets/images/govuk-crest.png',
+        logo:            'https://controlpanel.services.dev.mojanalytics.xyz/static/govuk-frontend/govuk/assets/images/govuk-logotype-crown.png',
         primaryColor:    '#000000'
       },
       prefill: loginHint ? { email: loginHint, username: loginHint } : null,


### PR DESCRIPTION
After some digging we found that the image in the Control Panel is
hosted/served at the following URL:

https://controlpanel.services.dev.mojanalytics.xyz/static/govuk-frontend/govuk/assets/images/govuk-logotype-crown.png

(`/static/govuk-frontend/govuk/assets/` not just `/static/govuk-frontend/assets/`)

Part of ticket: https://trello.com/c/eOEbYLn6