### PR TITLE
Use black SVG for higher contrast in login screens.

### DIFF
--- a/pages/login.html
+++ b/pages/login.html
@@ -143,7 +143,7 @@ Copyright © 2017 Javan Makhmali
         scope: "openid email profile repo read:user read:org",
       },
       theme: {
-        logo:            'https://controlpanel.services.dev.mojanalytics.xyz/static/govuk-frontend/govuk/assets/images/govuk-logotype-crown.png',
+        logo:            'https://controlpanel.services.dev.mojanalytics.xyz/static/govuk-frontend/govuk/assets/images/govuk-mask-icon.svg',
         primaryColor:    '#000000'
       },
       prefill: loginHint ? { email: loginHint, username: loginHint } : null,


### PR DESCRIPTION
Merging this PR will ensure the black SVG crown logo is used, thus providing higher contrast of the image on the login pages in `dev`. [This is the referenced image](https://controlpanel.services.dev.mojanalytics.xyz/static/govuk-frontend/govuk/assets/images/govuk-mask-icon.svg).

**NEEDS TESTING / CHECKING** cc/@xoen