### PR TITLE
Add try/catch around IP range check to deal with ipv6 issue (alpha)

### DIFF
--- a/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
+++ b/rules/Multifactor-Google-Authenticator-Do-Not-Rename.js
@@ -32,8 +32,14 @@ function (user, context, callback) {
         return callback(null, user, context);
     }
 
-    var userIsOnCorporateNetwork =
-        rangeCheck.inRange(context.request.ip, CORPORATE_NETWORK_CIDRS);
+    var userIsOnCorporateNetwork = false;
+    try {
+        userIsOnCorporateNetwork = rangeCheck.inRange(context.request.ip, CORPORATE_NETWORK_CIDRS);
+    } catch(error) {
+        // Log the IPv6 problem, just in case.
+        console.log("Connection from IPv6 address. Fall back to MFA.");
+        console.log(error);
+    }
     if (!userIsOnCorporateNetwork) {
         enableMFA(context);
     }


### PR DESCRIPTION
This fix ensures the errors encountered by those connecting via IPv6 disappear. We just force MFA since we can't compare IPv6 with IPv4 ranges (the original error causing the failure to log in).